### PR TITLE
fix roots in MetaModelicaJuliaLayer.h, function SourceInfo__SOURCEINFO

### DIFF
--- a/lib/parser/MetaModelicaJuliaLayer.c
+++ b/lib/parser/MetaModelicaJuliaLayer.c
@@ -82,3 +82,69 @@ void c_add_source_message(
     fprintf(stderr, "    Error token %d: %s\n", i+1, ctokens[i]);
   }
 }
+
+
+/*
+jl_value_t* mmc_mk_some_or_none(jl_value_t *value) {
+  JL_GC_PUSH1(&value); // make a root so GC can trac this one
+  jl_value_t* result = value ? jl_call1(omc_jl_some, value) : jl_nothing;
+  JL_GC_POP();
+  return result;
+}
+
+jl_value_t* mmc_mk_scon(const char *str) {
+  return jl_cstr_to_string(str);
+}
+
+jl_value_t* __mmc_mk_cons(jl_value_t* head, jl_value_t* tail) {
+  JL_GC_PUSH2(&head, &tail);  
+  jl_value_t *result = jl_call2(omc_jl_cons, head, tail);
+  assert(result);
+  JL_GC_POP();
+  return result;
+}
+
+jl_value_t* mmc_mk_cons_typed(jl_value_t* T, jl_value_t* head, jl_value_t* tail) {
+  JL_GC_PUSH3(&T, &head, &tail);
+  jl_value_t *result = jl_call3(omc_jl_cons_typed, T, head, tail);
+  assert(result);
+  JL_GC_POP();
+  return result;
+}
+
+
+#if !defined(JL_GC_PUSH9)
+#define JL_GC_PUSH9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)                      \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(9), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}; \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+#endif
+
+jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, int isReadOnly, int lineNumberStart, int columnNumberStart, int lineNumberEnd, int columnNumberEnd, double lastModification)
+{
+  jl_value_t* v1 = NULL, *v2 = NULL, *v3 = NULL, *v4 = NULL, *v5 = NULL, *v6 = NULL, *result = NULL, **vals = NULL;
+  JL_GC_PUSH9(&filename, &v1, &v2, &v3, &v4, &v5, &v6, &result, vals);
+  v1 = mmc_mk_bcon(isReadOnly);
+  v2 = mmc_mk_icon(lineNumberStart);
+  v3 = mmc_mk_icon(columnNumberStart);
+  v4 = mmc_mk_icon(lineNumberEnd);
+  v5 = mmc_mk_icon(columnNumberEnd);
+  v6 = mmc_mk_rcon(lastModification);
+  {
+    JL_GC_PUSHARGS(vals, 7);
+    vals[0] = fileName;
+    vals[1] = v1;
+    vals[2] = v2;
+    vals[3] = v3;
+    vals[4] = v4;
+    vals[5] = v5;
+    vals[6] = v6;   
+    result = jl_call(omc_jl_sourceinfo, vals, 7);
+    assert(result);
+    JL_GC_POP();
+  }
+  JL_GC_POP();
+  return result;
+}
+
+*/
+

--- a/lib/parser/MetaModelicaJuliaLayer.h
+++ b/lib/parser/MetaModelicaJuliaLayer.h
@@ -5,45 +5,6 @@
 
 #define jl_debug_println(X) jl_call1(jl_get_function(jl_base_module, "show"), (X));
 
-/* Note: These values may be garbage collected away? Call this before each file is parsed? */
-void OpenModelica_initMetaModelicaJuliaLayer();
-
-extern jl_function_t* omc_jl_some;
-extern jl_function_t* omc_jl_cons;
-extern jl_function_t* omc_jl_cons_typed;
-extern jl_function_t* omc_jl_sourceinfo;
-extern jl_function_t* omc_jl_listReverse;
-extern jl_function_t* omc_jl_listEmpty;
-extern jl_function_t* omc_jl_tuple2;
-extern jl_function_t* omc_jl_isDerCref;
-extern jl_value_t* omc_jl_nil;
-
-static inline jl_value_t* mmc_mk_some_or_none(jl_value_t *value) {
-  return value ? jl_call1(omc_jl_some, value) : jl_nothing;
-}
-
-static inline jl_value_t* mmc_mk_scon(const char *str) {
-  return jl_cstr_to_string(str);
-}
-
-static inline jl_value_t* __mmc_mk_cons(jl_value_t* head, jl_value_t* tail) {
-  jl_value_t *res = jl_call2(omc_jl_cons, head, tail);
-  assert(res);
-  return res;
-}
-
-static inline jl_value_t* mmc_mk_cons_typed(jl_value_t* T, jl_value_t* head, jl_value_t* tail) {
-  jl_value_t *res = jl_call3(omc_jl_cons_typed, T, head, tail);
-  assert(res);
-  return res;
-}
-
-static inline jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, jl_value_t* isReadOnly, jl_value_t* lineNumberStart, jl_value_t* columnNumberStart, jl_value_t* lineNumberEnd, jl_value_t* columnNumberEnd, jl_value_t* lastModification)
-{
-  jl_value_t *vals[7] = {fileName,isReadOnly,lineNumberStart,columnNumberStart,lineNumberEnd,columnNumberEnd,lastModification};
-  return jl_call(omc_jl_sourceinfo, vals, 7);
-}
-
 #define omc_AbsynUtil_isDerCref(IGNORE, X) (X ? jl_call1(omc_jl_isDerCref, X) : jl_nothing)
 #define mmc_mk_tuple2(x1,x2) (jl_call2(omc_jl_tuple2, x1, x2))
 
@@ -60,12 +21,94 @@ static inline jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, jl_value_
 #define listEmpty(X) (jl_true == jl_call1(omc_jl_listEmpty, (X)))
 #define optionNone(X) jl_is_nothing(X)
 
+/* Note: These values may be garbage collected away? Call this before each file is parsed? */
+void OpenModelica_initMetaModelicaJuliaLayer();
+
+extern jl_function_t* omc_jl_some;
+extern jl_function_t* omc_jl_cons;
+extern jl_function_t* omc_jl_cons_typed;
+extern jl_function_t* omc_jl_sourceinfo;
+extern jl_function_t* omc_jl_listReverse;
+extern jl_function_t* omc_jl_listEmpty;
+extern jl_function_t* omc_jl_tuple2;
+extern jl_function_t* omc_jl_isDerCref;
+extern jl_value_t* omc_jl_nil;
+
+/*
+extern jl_value_t* mmc_mk_some_or_none(jl_value_t *value);
+extern jl_value_t* mmc_mk_scon(const char *str);
+extern jl_value_t* __mmc_mk_cons(jl_value_t* head, jl_value_t* tail);
+extern jl_value_t* mmc_mk_cons_typed(jl_value_t* T, jl_value_t* head, jl_value_t* tail);
+extern jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, int isReadOnly, int lineNumberStart, int columnNumberStart, int lineNumberEnd, int columnNumberEnd, double lastModification);
+*/
+
+static inline jl_value_t* mmc_mk_some_or_none(jl_value_t *value) {
+  JL_GC_PUSH1(&value); // make a root so GC can trac this one
+  jl_value_t* result = value ? jl_call1(omc_jl_some, value) : jl_nothing;
+  JL_GC_POP();
+  return result;
+}
+
+static inline jl_value_t* mmc_mk_scon(const char *str) {
+  return jl_cstr_to_string(str);
+}
+
+static inline jl_value_t* __mmc_mk_cons(jl_value_t* head, jl_value_t* tail) {
+  JL_GC_PUSH2(&head, &tail);  
+  jl_value_t *result = jl_call2(omc_jl_cons, head, tail);
+  assert(result);
+  JL_GC_POP();
+  return result;
+}
+
+static inline jl_value_t* mmc_mk_cons_typed(jl_value_t* T, jl_value_t* head, jl_value_t* tail) {
+  JL_GC_PUSH3(&T, &head, &tail);
+  jl_value_t *result = jl_call3(omc_jl_cons_typed, T, head, tail);
+  assert(result);
+  JL_GC_POP();
+  return result;
+}
+
+
+#if !defined(JL_GC_PUSH9)
+#define JL_GC_PUSH9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)                      \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(9), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}; \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+#endif
+
+static inline jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, int isReadOnly, int lineNumberStart, int columnNumberStart, int lineNumberEnd, int columnNumberEnd, double lastModification)
+{
+  jl_value_t* v1 = NULL, *v2 = NULL, *v3 = NULL, *v4 = NULL, *v5 = NULL, *v6 = NULL, *result = NULL, **vals = NULL;
+  JL_GC_PUSH9(&fileName, &v1, &v2, &v3, &v4, &v5, &v6, &result, vals);
+  v1 = mmc_mk_bcon(isReadOnly);
+  v2 = mmc_mk_icon(lineNumberStart);
+  v3 = mmc_mk_icon(columnNumberStart);
+  v4 = mmc_mk_icon(lineNumberEnd);
+  v5 = mmc_mk_icon(columnNumberEnd);
+  v6 = mmc_mk_rcon(lastModification);
+  {
+    JL_GC_PUSHARGS(vals, 7);
+    vals[0] = fileName;
+    vals[1] = v1;
+    vals[2] = v2;
+    vals[3] = v3;
+    vals[4] = v4;
+    vals[5] = v5;
+    vals[6] = v6;   
+    result = jl_call(omc_jl_sourceinfo, vals, 7);
+    assert(result);
+    JL_GC_POP();
+  }
+  JL_GC_POP();
+  return result;
+}
+
 enum enumErrorType {ErrorType_syntax=0,ErrorType_grammar,ErrorType_translation,ErrorType_symbolic,ErrorType_runtime,ErrorType_scripting};
 enum enumErrorLevel {ErrorLevel_internal=0,ErrorLevel_error,ErrorLevel_warning,ErrorLevel_notification};
 typedef enum enumErrorType ErrorType;
 typedef enum enumErrorLevel ErrorLevel;
 
-void c_add_source_message(
+extern void c_add_source_message(
        void *dummy,
        int errorID,
        ErrorType type,

--- a/lib/parser/Modelica.g
+++ b/lib/parser/Modelica.g
@@ -85,7 +85,7 @@ goto rule ## func ## Ex; }}
   #include "ModelicaParserCommon.h"
 
   /* Julia */
-  #define PARSER_INFO(start) ((void*) SourceInfo__SOURCEINFO(ModelicaParser_filename_OMC, mmc_mk_bcon(ModelicaParser_readonly), mmc_mk_icon(start->line), mmc_mk_icon(start->line == 1 ? start->charPosition+2 : start->charPosition+1), mmc_mk_icon(LT(1)->line), mmc_mk_icon(LT(1)->charPosition+1), mmc_mk_rcon(0.0)))
+  #define PARSER_INFO(start) (SourceInfo__SOURCEINFO(ModelicaParser_filename_OMC, ModelicaParser_readonly, start->line, start->line == 1 ? start->charPosition+2 : start->charPosition+1, LT(1)->line, LT(1)->charPosition+1, 0.0))
   #define isCref(X) jl_typeis(X, Absyn_Exp_CREF_type)
   #define isPath(X) jl_typeis(X, Absyn_TypeSpec_TPATH_type)
   #define isComplex(X) jl_typeis(X, Absyn_TypeSpec_TCOMPLEX_type)
@@ -126,18 +126,18 @@ goto rule ## func ## Ex; }}
   /* uncomment this to stress test the code by doing gc at each function start
    * 0 = auto, 1 = full, 2 = incremental
    */
-  #define jlgc(NN) /* jl_gc_collect(NN) */
-  #define OM_PUSHZ1(A) (A) = NULL; jlgc(1); JL_GC_PUSH1(&(A)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ2(A,B) (A) = NULL; (B) = NULL; jlgc(1); JL_GC_PUSH2(&(A),&(B)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ3(A,B,C) (A) = NULL; (B) = NULL; (C) = NULL; jlgc(1); JL_GC_PUSH3(&(A),&(B),&(C)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ4(A,B,C,D) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; jlgc(1); JL_GC_PUSH4(&(A),&(B),&(C),&(D)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ5(A,B,C,D,E) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; jlgc(1); JL_GC_PUSH5(&(A),&(B),&(C),&(D),&(E)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ6(A,B,C,D,E,F) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; jlgc(1); JL_GC_PUSH6(&(A),&(B),&(C),&(D),&(E),&(F)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ7(A,B,C,D,E,F,G) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; jlgc(1); JL_GC_PUSH7(&(A),&(B),&(C),&(D),&(E),&(F),&(G)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ8(A,B,C,D,E,F,G,H) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; jlgc(1); JL_GC_PUSH8(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ9(A,B,C,D,E,F,G,H,I) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; jlgc(1); JL_GC_PUSH9(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ10(A,B,C,D,E,F,G,H,I,J) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; (J) = NULL; jlgc(1); JL_GC_PUSH10(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I),&(J)); ctx->pModelicaParser_omcTop->numPushed+=1;
-  #define OM_PUSHZ11(A,B,C,D,E,F,G,H,I,J,K) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; (J) = NULL; (K) = NULL; jlgc(1); JL_GC_PUSH11(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I),&(J),&(K)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define jlgc() /* jl_gc_collect(rand() \% 2) */
+  #define OM_PUSHZ1(A) (A) = NULL; jlgc(); JL_GC_PUSH1(&(A)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ2(A,B) (A) = NULL; (B) = NULL; jlgc(); JL_GC_PUSH2(&(A),&(B)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ3(A,B,C) (A) = NULL; (B) = NULL; (C) = NULL; jlgc(); JL_GC_PUSH3(&(A),&(B),&(C)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ4(A,B,C,D) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; jlgc(); JL_GC_PUSH4(&(A),&(B),&(C),&(D)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ5(A,B,C,D,E) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; jlgc(); JL_GC_PUSH5(&(A),&(B),&(C),&(D),&(E)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ6(A,B,C,D,E,F) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; jlgc(); JL_GC_PUSH6(&(A),&(B),&(C),&(D),&(E),&(F)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ7(A,B,C,D,E,F,G) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; jlgc(); JL_GC_PUSH7(&(A),&(B),&(C),&(D),&(E),&(F),&(G)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ8(A,B,C,D,E,F,G,H) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; jlgc(); JL_GC_PUSH8(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ9(A,B,C,D,E,F,G,H,I) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; jlgc(); JL_GC_PUSH9(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ10(A,B,C,D,E,F,G,H,I,J) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; (J) = NULL; jlgc(); JL_GC_PUSH10(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I),&(J)); ctx->pModelicaParser_omcTop->numPushed+=1;
+  #define OM_PUSHZ11(A,B,C,D,E,F,G,H,I,J,K) (A) = NULL; (B) = NULL; (C) = NULL; (D) = NULL; (E) = NULL; (F) = NULL; (G) = NULL; (H) = NULL; (I) = NULL; (J) = NULL; (K) = NULL; jlgc(); JL_GC_PUSH11(&(A),&(B),&(C),&(D),&(E),&(F),&(G),&(H),&(I),&(J),&(K)); ctx->pModelicaParser_omcTop->numPushed+=1;
   #define OM_POP(NN) ctx->pModelicaParser_omcTop->numPushed=ctx->pModelicaParser_omcTop->numPushed-1; JL_GC_POP();
 }
 


### PR DESCRIPTION
In the parser we called SourceInfo__SOURCEINFO with calls to other Julia functions that might call the GC but we did not declare the roots. Send in raw C data, call the Julia functions inside SourceInfo__SOURCEINFO, with proper roots declared.