### PR TITLE
Fix parser error messages and added syntax regression tests

### DIFF
--- a/lib/parser/MetaModelicaJuliaLayer.c
+++ b/lib/parser/MetaModelicaJuliaLayer.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <julia.h>
 #include "MetaModelicaJuliaLayer.h"
 
@@ -66,6 +68,144 @@ void OpenModelica_initMetaModelicaJuliaLayer()
   assert((omc_jl_nil = jl_get_global(ListDefModule, jl_symbol("nil"))));
 }
 
+static const char* source_message_token(const char** ctokens, int nTokens, int tokenIndex)
+{
+  const char* token = "";
+
+  if (ctokens != NULL && tokenIndex < nTokens) {
+    if (ctokens[tokenIndex] != NULL) {
+      token = ctokens[tokenIndex];
+    }
+  }
+
+  return token;
+}
+
+static size_t formatted_source_message_length(const char* message, const char** ctokens, int nTokens)
+{
+  int tokenIndex = 0;
+  size_t length = 0;
+
+  for (size_t i = 0; message[i] != '\0'; ++i) {
+    if (message[i] == '%' && message[i+1] != '\0') {
+      if (message[i+1] == '%') {
+        ++length;
+        ++i;
+        continue;
+      }
+
+      if (message[i+1] == 's') {
+        length += strlen(source_message_token(ctokens, nTokens, tokenIndex));
+        ++tokenIndex;
+        ++i;
+        continue;
+      }
+    }
+
+    ++length;
+  }
+
+  return length;
+}
+
+static char* format_source_message(const char* message, const char** ctokens, int nTokens)
+{
+  char* formatted = NULL;
+  int tokenIndex = 0;
+  size_t writeIndex = 0;
+
+  if (message == NULL) {
+    return NULL;
+  }
+
+  formatted = malloc(formatted_source_message_length(message, ctokens, nTokens) + 1);
+  if (formatted == NULL) {
+    return NULL;
+  }
+
+  for (size_t i = 0; message[i] != '\0'; ++i) {
+    const char* replacement = NULL;
+    size_t replacementLength = 0;
+
+    if (message[i] == '%' && message[i+1] != '\0') {
+      if (message[i+1] == '%') {
+        replacement = "%";
+        replacementLength = 1;
+        ++i;
+      } else if (message[i+1] == 's') {
+        replacement = source_message_token(ctokens, nTokens, tokenIndex);
+        replacementLength = strlen(replacement);
+        ++tokenIndex;
+        ++i;
+      }
+    }
+
+    if (replacement != NULL) {
+      memcpy(formatted + writeIndex, replacement, replacementLength);
+      writeIndex += replacementLength;
+    } else {
+      formatted[writeIndex++] = message[i];
+    }
+  }
+
+  formatted[writeIndex] = '\0';
+  return formatted;
+}
+
+static void set_last_error_message(const char* rendered_message, jl_value_t* filename, int startLine, int startCol, int endLine, int endCol)
+{
+  parser_members* members = pthread_getspecific(modelicaParserKey);
+  int written = 0;
+  size_t capacity = 0;
+  char* updated = NULL;
+
+  if (members == NULL || rendered_message == NULL) {
+    return;
+  }
+
+  free(members->last_error_message);
+  members->last_error_message = NULL;
+
+  written = snprintf(NULL, 0, "%s:%d:%d-%d:%d: %s",
+    jl_string_data(filename), startLine, startCol, endLine, endCol, rendered_message);
+  if (written < 0) {
+    return;
+  }
+
+  capacity = (size_t) written + 1;
+  updated = (char*) malloc(capacity);
+  if (updated == NULL) {
+    return;
+  }
+
+  snprintf(updated, capacity, "%s:%d:%d-%d:%d: %s",
+    jl_string_data(filename), startLine, startCol, endLine, endCol, rendered_message);
+  members->last_error_message = updated;
+}
+
+OMPARSER_EXPORT const char* OMParser_lastErrorMessage(void)
+{
+  parser_members* members = pthread_getspecific(modelicaParserKey);
+
+  if (members == NULL) {
+    return NULL;
+  }
+
+  return members->last_error_message;
+}
+
+OMPARSER_EXPORT void OMParser_clearLastErrorMessage(void)
+{
+  parser_members* members = pthread_getspecific(modelicaParserKey);
+
+  if (members == NULL) {
+    return;
+  }
+
+  free(members->last_error_message);
+  members->last_error_message = NULL;
+}
+
 void c_add_source_message(
        void *dummy,
        int errorID,
@@ -81,11 +221,16 @@ void c_add_source_message(
        int isReadOnly,
        jl_value_t* filename)
 {
-  int i;
-  fprintf(stderr, "%s:%d:%d-%d:%d: %s\n", jl_string_data(filename), startLine, startCol, endLine, endCol, message);
-  for (i=0; i<nTokens; i++) {
-    fprintf(stderr, "    Error token %d: %s\n", i+1, ctokens[i]);
+  char* formatted = format_source_message(message, ctokens, nTokens);
+  const char* rendered = message;
+
+  if (formatted != NULL) {
+    rendered = formatted;
   }
+
+  set_last_error_message(rendered, filename, startLine, startCol, endLine, endCol);
+  fprintf(stderr, "%s:%d:%d-%d:%d: %s\n", jl_string_data(filename), startLine, startCol, endLine, endCol, rendered);
+  free(formatted);
 }
 
 
@@ -152,4 +297,3 @@ jl_value_t* SourceInfo__SOURCEINFO(jl_value_t* fileName, int isReadOnly, int lin
 }
 
 */
-

--- a/lib/parser/MetaModelicaJuliaLayer.h
+++ b/lib/parser/MetaModelicaJuliaLayer.h
@@ -1,7 +1,7 @@
 #if !defined(__METAMODELICA_JULIA_LAYER__H)
 #define __METAMODELICA_JULIA_LAYER__H
 
-#include <julia.h>
+#include "ModelicaParserCommon.h"
 
 #define jl_debug_println(X) jl_call1(jl_get_function(jl_base_module, "show"), (X));
 
@@ -91,7 +91,7 @@ static inline jl_value_t* mmc_mk_cons_typed(jl_value_t* T, jl_value_t* head, jl_
 
 #if !defined(JL_GC_PUSH1)
 #define JL_GC_PUSH1(arg1)                      \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(1), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7}; \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(1), jl_pgcstack, arg1}; \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 #endif
 
@@ -147,6 +147,9 @@ extern void c_add_source_message(
        int endCol,
        int isReadOnly,
        jl_value_t* filename);
+
+OMPARSER_EXPORT extern const char* OMParser_lastErrorMessage(void);
+OMPARSER_EXPORT extern void OMParser_clearLastErrorMessage(void);
 
 /* TODO: These should probably be some calls to Julia iconv functions? Or real iconv, who knows... */
 #define SystemImpl__iconv(STR,FROM,TO,ERR) STR

--- a/lib/parser/ModelicaParserCommon.h
+++ b/lib/parser/ModelicaParserCommon.h
@@ -37,15 +37,15 @@ extern "C" {
 #endif
 
 #if defined(_WIN32)
-#define DLLDirection __declspec(dllexport)
+#define OMPARSER_EXPORT __declspec(dllexport)
 #else
-#define DLLDirection /* nothing */
+#define OMPARSER_EXPORT /* nothing */
 #endif
 
 #include <julia.h>
 #include <pthread.h>
 
-DLLDirection extern pthread_key_t modelicaParserKey;
+OMPARSER_EXPORT extern pthread_key_t modelicaParserKey;
 
 #define omc_first_comment ((parser_members*)pthread_getspecific(modelicaParserKey))->first_comment
 #define ModelicaParser_filename_OMC ((parser_members*)pthread_getspecific(modelicaParserKey))->filename_OMC
@@ -67,6 +67,7 @@ typedef struct antlr_members_struct {
   void* timestamp;
   jl_value_t* filename_C;
   jl_value_t* filename_C_testsuiteFriendly;
+  char* last_error_message;
   int readonly;
   int flags;
   int langStd;

--- a/lib/parser/Parser_jl.c
+++ b/lib/parser/Parser_jl.c
@@ -56,9 +56,37 @@
 pthread_once_t parser_once_create_key = PTHREAD_ONCE_INIT;
 pthread_key_t modelicaParserKey;
 
+static void free_parser_members(void *state)
+{
+  parser_members *members = state;
+
+  if (members == NULL) {
+    return;
+  }
+
+  free(members->last_error_message);
+  free(members);
+}
+
 static void make_key()
 {
-  pthread_key_create(&modelicaParserKey, NULL);
+  pthread_key_create(&modelicaParserKey, free_parser_members);
+}
+
+static parser_members* get_parser_members(void)
+{
+  parser_members *members = pthread_getspecific(modelicaParserKey);
+
+  if (members == NULL) {
+    members = calloc(1, sizeof(parser_members));
+    if (members == NULL) {
+      return NULL;
+    }
+
+    pthread_setspecific(modelicaParserKey, members);
+  }
+
+  return members;
 }
 
 static void lexNoRecover(pANTLR3_LEXER lexer)
@@ -346,12 +374,11 @@ static void* parseStream(pANTLR3_INPUT_STREAM input)
   return res;
 }
 
-DLLDirection jl_value_t* parseString(jl_value_t* contents, jl_value_t* interactiveFileName, int acceptedGrammar, int langStd)
+OMPARSER_EXPORT jl_value_t* parseString(jl_value_t* contents, jl_value_t* interactiveFileName, int acceptedGrammar, int langStd)
 {
   pANTLR3_UINT8               fName;
   pANTLR3_INPUT_STREAM        input;
-
-  parser_members members;
+  parser_members             *members;
 
   int flags = PARSE_MODELICA;
   if(acceptedGrammar == 2) flags |= PARSE_META_MODELICA;
@@ -360,16 +387,25 @@ DLLDirection jl_value_t* parseString(jl_value_t* contents, jl_value_t* interacti
   else if(acceptedGrammar == 5) flags |= PARSE_PDEMODELICA;
 
   pthread_once(&parser_once_create_key,make_key);
-  pthread_setspecific(modelicaParserKey,&members);
+  members = get_parser_members();
+  if (members == NULL) {
+    fprintf(stderr, "Out of memory trying to allocate parser thread state\n");
+    fflush(stderr);
+    exit(ANTLR3_ERR_NOMEM);
+  }
 
-  members.encoding = "UTF-8";
-  members.filename_C = interactiveFileName;
-  members.filename_C_testsuiteFriendly = interactiveFileName;
-  members.filename_OMC = interactiveFileName;
-  members.flags = flags;
-  members.readonly = 1;
-  members.langStd = langStd;
-  members.first_comment = 0;
+  OMParser_clearLastErrorMessage();
+
+  members->encoding = "UTF-8";
+  members->filename_C = interactiveFileName;
+  members->filename_C_testsuiteFriendly = interactiveFileName;
+  members->filename_OMC = interactiveFileName;
+  members->timestamp = NULL;
+  members->flags = flags;
+  members->readonly = 1;
+  members->langStd = langStd;
+  members->first_comment = 0;
+  members->lexerError = 0;
 
   fName  = (pANTLR3_UINT8)jl_string_data(interactiveFileName);
 #if defined(ANTLR_C_VERSION_3_2)
@@ -387,12 +423,11 @@ DLLDirection jl_value_t* parseString(jl_value_t* contents, jl_value_t* interacti
 }
 
 
-DLLDirection jl_value_t* parseFile(jl_value_t *fileName, int acceptedGrammar, int langStd)
+OMPARSER_EXPORT jl_value_t* parseFile(jl_value_t *fileName, int acceptedGrammar, int langStd)
 {
   pANTLR3_UINT8               fName;
   pANTLR3_INPUT_STREAM        input;
-
-  parser_members members;
+  parser_members             *members;
 
   int flags = PARSE_MODELICA;
   if(acceptedGrammar == 2) flags |= PARSE_META_MODELICA;
@@ -401,16 +436,25 @@ DLLDirection jl_value_t* parseFile(jl_value_t *fileName, int acceptedGrammar, in
   else if(acceptedGrammar == 5) flags |= PARSE_PDEMODELICA;
 
   pthread_once(&parser_once_create_key,make_key);
-  pthread_setspecific(modelicaParserKey,&members);
+  members = get_parser_members();
+  if (members == NULL) {
+    fprintf(stderr, "Out of memory trying to allocate parser thread state\n");
+    fflush(stderr);
+    exit(ANTLR3_ERR_NOMEM);
+  }
 
-  members.encoding = "UTF-8";
-  members.filename_C = fileName;
-  members.filename_C_testsuiteFriendly = fileName;
-  members.filename_OMC = fileName;
-  members.flags = flags;
-  members.readonly = 0;
-  members.langStd = langStd;
-  members.first_comment = 0;
+  OMParser_clearLastErrorMessage();
+
+  members->encoding = "UTF-8";
+  members->filename_C = fileName;
+  members->filename_C_testsuiteFriendly = fileName;
+  members->filename_OMC = fileName;
+  members->timestamp = NULL;
+  members->flags = flags;
+  members->readonly = 0;
+  members->langStd = langStd;
+  members->first_comment = 0;
+  members->lexerError = 0;
 
   fName  = (pANTLR3_UINT8)jl_string_data(fileName);
   input  = antlr3AsciiFileStreamNew(fName);

--- a/src/OMParser.jl
+++ b/src/OMParser.jl
@@ -15,7 +15,25 @@ Directory containing externally downloaded shared libraries.
 """
 const SHARED_DIRECTORY_PATH = joinpath(INSTALLATION_DIRECTORY_PATH, "lib", "ext")
 
-struct ParseError end
+struct ParseError <: Exception
+  message::String
+end
+
+ParseError() = ParseError("Parsing failed")
+
+function Base.showerror(io::IO, err::ParseError)
+  print(io, err.message)
+end
+
+function last_parse_error_message()
+  ptr = ccall((:OMParser_lastErrorMessage, ensure_installed_lib_path()), Cstring, ())
+  ptr == C_NULL && return nothing
+  try
+    unsafe_string(ptr)
+  finally
+    ccall((:OMParser_clearLastErrorMessage, ensure_installed_lib_path()), Cvoid, ())
+  end
+end
 
 function isDerCref(exp::Absyn.Exp)::Bool
   @match exp begin
@@ -73,7 +91,7 @@ function parseString(contents::String,
                      languageStandard::Int64 = 1000)::Absyn.Program
   local res = ccall((:parseString, ensure_installed_lib_path()), Any, (String, String, Int64, Int64), contents, interactiveFileName, acceptedGram, languageStandard)
   if res == nothing
-    throw(ParseError())
+    throw(ParseError(something(last_parse_error_message(), "Parsing failed")))
   end
   res
 end
@@ -99,7 +117,7 @@ Grammar mapping for the `acceptedGram` variable:
 function parseFile(fileName::String, acceptedGram::Int64 = 1, languageStandard::Int64 = 9999)::Absyn.Program
   local res = ccall((:parseFile, ensure_installed_lib_path()), Any, (String, Int64, Int64), fileName, acceptedGram, languageStandard)
   if res == nothing
-    throw(ParseError())
+    throw(ParseError(something(last_parse_error_message(), "Parsing failed")))
   end
   res
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,68 +2,106 @@ using Test
 
 import OMParser
 
-@testset "Simple standalone modules" begin
-  @test true == begin
-    try
-      res = OMParser.parseFile("HelloWorld.mo")
-      true
-    catch err
-      @info("Test failed with the following error:")
-      @info "Error:" err
-      false
+cd(@__DIR__) do
+  @testset "Simple standalone modules" begin
+    @test true == begin
+      try
+        res = OMParser.parseFile("HelloWorld.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
+    end
+
+    @test true == begin
+      try
+        res = OMParser.parseFile("Influenza.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
+    end
+
+    @test true == begin
+      try
+        res = OMParser.parseFile("Casc12800.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
+    end
+
+  end
+
+  @testset "Test OMCompiler.jl specific extensions" begin
+    @test true == begin
+      try
+        res = OMParser.parseFile("BreakingPendulum.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
     end
   end
 
-  @test true == begin
-    try
-      res = OMParser.parseFile("Influenza.mo")
-      true
-    catch err
-      @info("Test failed with the following error:")
-      @info "Error:" err
-      false
+  @testset "Syntax error reporting" begin
+    function parse_error_message(contents::String, file_name::String)
+      try
+        OMParser.parseString(contents, file_name)
+        return nothing
+      catch err
+        @test err isa OMParser.ParseError
+        return sprint(showerror, err)
+      end
     end
+
+    bad_contents = "model X\n  Real x\nequation\n  x = ;\nend X;\n"
+    good_contents = "model Good\n  Real x;\nend Good;\n"
+
+    first_error = parse_error_message(bad_contents, "bad1.mo")
+    @test first_error !== nothing
+    @test occursin("bad1.mo", first_error)
+    @test occursin("Missing token: SEMICOLON", first_error)
+
+    @test true == begin
+      try
+        OMParser.parseString(good_contents, "good.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
+    end
+
+    second_error = parse_error_message(bad_contents, "bad2.mo")
+    @test second_error !== nothing
+    @test occursin("bad2.mo", second_error)
+    @test occursin("Missing token: SEMICOLON", second_error)
   end
 
-  @test true == begin
-    try
-      res = OMParser.parseFile("Casc12800.mo")
-      true
-    catch err
-      @info("Test failed with the following error:")
-      @info "Error:" err
-      false
-    end
-  end
+  #= Tests to see if the parser can handle the MM language.=#
+  include("metaModelicaTests.jl")
 
-end
-
-@testset "Test OMCompiler.jl specific extensions" begin
-  @test true == begin
-    try
-      res = OMParser.parseFile("BreakingPendulum.mo")
-      true
-    catch err
-      @info("Test failed with the following error:")
-    @info "Error:" err
-      false
-    end
-  end
-end
-
-#= Tests to see if the parser can handle the MM language.=#
-include("metaModelicaTests.jl")
-
-#= Warning might be flaky... =#
-@testset "Standard Library" begin
-  @test true == begin
-    try
-      res = OMParser.parseFile("msl.mo")
-      true
-    catch err
-      @info("Test failed with the following error:")
-      @info "Error:" err
-      false
+  #= Warning might be flaky... =#
+  @testset "Standard Library" begin
+    @test true == begin
+      try
+        res = OMParser.parseFile("msl.mo")
+        true
+      catch err
+        @info("Test failed with the following error:")
+        @info "Error:" err
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
  - format  parser diagnostics before printing
  - propagate parse errors into ParseError(message)
  - move last-error storage into thread-local parser state
  - rename the export macro to OMPARSER_EXPORT
  - fix the fallback JL_GC_PUSH1 helper macro
  - add syntax-error regression tests and make runtests.jl independent of the working directory
  - rebuild the native library and rerun the full test suite successfully