### PR TITLE
Fix Windows/WSL precompilation: resolve Absyn via Base.require (v0.1.0)

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -16,10 +16,13 @@ on:
         options:
           - '["1.12"]'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ${{ matrix.sys.os }}
     strategy:
+      fail-fast: false
       matrix:
         sys:
           - { os: windows-latest, shell: 'msys2 {0}' }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMParser"
 uuid = "11f87224-cae7-4e99-a924-e50d12f62c59"
 authors = ["Adrian Pop <adrian.pop@liu.se>", "John Tinnerholm <john.tinnerholm@liu.se>"]
-version = "0.0.6"
+version = "0.1.0"
 
 [deps]
 Absyn = "ce2f92e2-a952-11e9-0543-8b443f216f1d"

--- a/lib/parser/GenerateJLHeader.jl
+++ b/lib/parser/GenerateJLHeader.jl
@@ -238,11 +238,14 @@ end
 """
 function generateJL_Asserts(allDataTypes, moduleName)
   local buffer = IOBuffer()
+  #= Resolve the module via Base.require instead of `using` so no binding is
+     created in Main; required for Julia 1.12+ incremental precompilation. =#
+  local moduleUUID = string(Base.PkgId(getproperty(Main, Symbol(moduleName))).uuid)
+  local requireExpr = "Base.require(Base.PkgId(Base.UUID(\\\"$(moduleUUID)\\\"), \\\"$(moduleName)\\\"))"
   local preamble = "
-      jl_eval_string(\"using $(moduleName)\");
-      jl_module_t* $(moduleName) = (jl_module_t *) jl_eval_string(\"$(moduleName)\");
+      jl_module_t* $(moduleName) = (jl_module_t *) jl_eval_string(\"$(requireExpr)\");
       if (!$(moduleName)) {
-        fprintf(stderr, \"module $(moduleName) not loaded, load it via using $(moduleName).\");
+        fprintf(stderr, \"module $(moduleName) not loaded.\");
         fflush(NULL);
       }
       assert(jl_is_module($(moduleName)));"

--- a/src/OMParser.jl
+++ b/src/OMParser.jl
@@ -8,7 +8,7 @@ import Glob
 """
 The path were the package is located.
 """
-const INSTALLATION_DIRECTORY_PATH = normpath(joinpath(dirname(Base.find_package("OMParser")), ".."))
+const INSTALLATION_DIRECTORY_PATH = normpath(joinpath(@__DIR__, ".."))
 
 """
 Directory containing externally downloaded shared libraries.


### PR DESCRIPTION
This is SVAGEN26 (JKRT_CLAUDE), the Claude Code agent account acting on behalf of @JKRT.

## Problem

`using OMFrontend` (and any package whose precompile workload calls `parseFile`) crashes during precompilation on Windows / Julia 1.12 with `EXCEPTION_ACCESS_VIOLATION`, and on a plain runtime path with `Creating a new global in closed module Main (Absyn)`.

Root cause: the auto-generated `OpenModelica_initAbsynReferences` (from `lib/parser/GenerateJLHeader.jl`) resolves the `Absyn` module with:

```c
jl_eval_string("using Absyn");
jl_module_t* Absyn = jl_eval_string("Absyn");
```

This mutates `Main`, which Julia 1.12 forbids during incremental precompilation. The hand-written `MetaModelicaJuliaLayer.c` was already migrated to `Base.require(Base.PkgId(UUID, name))` for exactly this reason ("required for Julia 1.12+ precompilation compatibility"); the generated Absyn header was missed.

## Fix

- `lib/parser/GenerateJLHeader.jl`: generate `Base.require(Base.PkgId(Base.UUID("<uuid>"), "Absyn"))` instead of `using Absyn`. This returns the module without binding any name in `Main`. The UUID is derived from the loaded module at generation time. (Mirrors the already-blessed pattern in `MetaModelicaJuliaLayer.c`.)
- `src/OMParser.jl`: use `@__DIR__` for `INSTALLATION_DIRECTORY_PATH` (`Base.find_package` returns `nothing` for transitive dependencies).
- Bump version to `0.1.0`.
- CI (`manual.yml`): set `fail-fast: false` and `permissions: contents: write` so a per-OS release-step issue does not cancel sibling builds and the release action can create tags on forks.

## Verification

The fork CI built the parser library on the GitHub Windows runner with this change, and it was tested end-to-end on Windows (`julia.exe`, Julia 1.12.6 under WSL):

- `configure / make` builds the DLL cleanly with the regenerated header (Windows, macOS, Linux)
- `Pkg.test("OMParser")` passes
- Downstream OMFrontend cold-precompiles with its full `@compile_workload` enabled (parses the builtin library and translates MSL models, all calling `parseFile` during precompilation) — no crash, no skip, no `Main`-binding hack
- Runtime `parseFile` returns `Absyn.PROGRAM`; `Main.Absyn` is not polluted