### PR TITLE
Add nightly drift check for published parser binaries

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,55 @@
+name: Nightly Drift Check
+
+# Detects drift between the PUBLISHED parser binaries (the rolling
+# `Latest-<os>-julia-<ver>` release assets that deps/build.jl downloads) and the
+# current OMJL source/stack. It performs a clean, end-user install of OMFrontend
+# straight from the registry — which downloads the published binary — and smoke
+# tests it. If a stale or broken binary is published (as happened when the
+# `Base.require` parser fix shipped in source but the binaries lagged ~2 months),
+# this job turns red so the drift is caught within a day instead of by users.
+
+on:
+  schedule:
+    # 01:00 UTC. GitHub Actions cron is always UTC and does NOT observe DST, so
+    # this fires at 03:00 Swedish summer time (CEST, UTC+2) and 02:00 in winter
+    # (CET, UTC+1). Adjust to '0 2 * * *' if you prefer 03:00 during winter.
+    - cron: '0 1 * * *'
+  # Allow on-demand runs from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    name: Install & smoke-test (${{ matrix.os }}, Julia ${{ matrix.julia-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        julia-version: ['1.12']
+    steps:
+      - name: setup julia environment
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - name: Clean end-user install of OMFrontend from the registry
+        shell: bash
+        run: |
+          julia --color=yes -e '
+            using Pkg
+            Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/OpenModelica/OpenModelicaRegistry.git"))
+            Pkg.Registry.add("General")
+            # Installing from the registry runs OMParser deps/build.jl, which downloads
+            # the published Latest-<os>-julia-<ver> parser binary for this OS.
+            Pkg.add("OMFrontend")
+            # `using` runs OMFrontend.__init__, which parses the builtin library through
+            # the native parser — the exact step a stale/broken binary crashes on.
+            using OMFrontend
+            model = "model HelloWorld\n  Real x(start = 1.0);\nequation\n  der(x) = -x;\nend HelloWorld;\n"
+            tmp = tempname() * ".mo"; write(tmp, model)
+            prog  = OMFrontend.parseFile(tmp, 1)
+            scode = OMFrontend.translateToSCode(prog)
+            @assert prog  !== nothing "parseFile returned nothing"
+            @assert scode !== nothing "translateToSCode returned nothing"
+            @info "OMFrontend drift smoke test OK" julia=VERSION parsed=typeof(prog) scode=typeof(scode)
+          '


### PR DESCRIPTION
Adds `.github/workflows/drift-check.yml`: a scheduled (**03:00 Swedish time**, `0 1 * * *` UTC) and manually dispatchable workflow that does a clean **end-user** install of `OMFrontend` from the OpenModelica registry on ubuntu/windows/macOS (Julia 1.12) and smoke-tests parse + SCode translation.

**Why.** Installing from the registry runs OMParser's `deps/build.jl`, which downloads the published `Latest-<os>-julia-<ver>` parser binary. So this exercises the *published* artifact, not a fresh local build. It catches drift between the published binaries and the source — e.g. the recent case where the `Base.require` parser fix landed in source on 2026-06-18 but the binaries stayed at the 2026-04-22 build, segfaulting Windows installs on Julia 1.12. A nightly red build surfaces that within a day instead of via user reports.

**Schedule note.** GitHub Actions cron is always UTC and does not observe DST, so `0 1 * * *` = 03:00 in Swedish summer time (CEST, UTC+2) and 02:00 in winter (CET, UTC+1). Switch to `0 2 * * *` to prefer 03:00 during winter.

Complements (but is independent of) the separate `PARSER_ABI_VERSION` fail-loud + auto-republish hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)